### PR TITLE
Allow ruby 2.7

### DIFF
--- a/i18n-inflector-rails.gemspec
+++ b/i18n-inflector-rails.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.rubyforge_project = '[none]'
   s.required_rubygems_version = '>= 1.4.0'
-  s.required_ruby_version = '>= 3'
+  s.required_ruby_version = '>= 2.7'
   s.specification_version = 3
 
   s.add_dependency 'i18n-inflector',          '~> 2.6'


### PR DESCRIPTION
There is no need to require >= 3, it works perfectly fine with 2.7 and 2.7 is still supported until March 2023. This allows us to support ruby 2.7 and 3.0 at the same time.

Also, it would be great to get an actual release of #10 and this.